### PR TITLE
Add header to split_text.py

### DIFF
--- a/split_text.py
+++ b/split_text.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
 import glob, os
 
 import pdftotext


### PR DESCRIPTION
Adding header to set encoding to split_text.py.
Otherwise I get:

```
SyntaxError: Non-ASCII character '\xe7' in file ./split_text.py on line 52, but no encoding declared; see http://python.org/dev/peps/pep-0263/ for details
```