### PR TITLE
Add support for Italian (DEIT)

### DIFF
--- a/split_text.py
+++ b/split_text.py
@@ -27,6 +27,10 @@ ACCEPTED_PDFS = (
 	'GLOSSIKA-PBENFR-F1-EBK new.pdf',
 	'GLOSSIKA-PBENFR-F2-EBK new.pdf',
 	'GLOSSIKA-PBENFR-F3-EBK new.pdf',
+	# Italian
+	'GLOSSIKA-DEIT-F1-EBK.pdf',
+	'GLOSSIKA-DEIT-F2-EBK.pdf',
+	'GLOSSIKA-DEIT-F3-EBK.pdf',
 )
 
 BOOKS = {
@@ -68,6 +72,15 @@ BOOKS = {
 		'F1': [48, 369],
 		'F2': [48, 428],
 		'F3': [48, 473],
+	},
+
+	# Italian
+	'DEIT': {
+		'languages': ['EN', 'CA'],
+		'types': ['DE', 'IT', 'IPA'],
+		'F1': [33, 263],
+		'F2': [33, 295],
+		'F3': [33, 329],
 	},
 }
 


### PR DESCRIPTION
Trying to add DEIT support.
This is what happens:

```
tree texts
texts
├── GLOSSIKA-DEIT-F1-EBK.pdf
├── GLOSSIKA-DEIT-F2-EBK.pdf
└── GLOSSIKA-DEIT-F3-EBK.pdf

python3 ./split_text.py
Checking 'texts/GLOSSIKA-DEIT-F2-EBK.pdf'
Traceback (most recent call last):
  File "./split_text.py", line 336, in <module>
    split()
  File "./split_text.py", line 332, in split
    split_text('', glob.glob(location), 'output', '')
  File "./split_text.py", line 327, in split_text
    extract_sentences(book, book_info, language_pair, series, callback)
  File "./split_text.py", line 278, in extract_sentences
    sentence.sentence = phrase
UnboundLocalError: local variable 'sentence' referenced before assignment
```

Any idea? :-)