### PR TITLE
Add support for DEIT to split_gms

### DIFF
--- a/split_gms.py
+++ b/split_gms.py
@@ -22,6 +22,7 @@ LANGUAGES = {
 	'ENZT': ('EN', 'ZT'),
 	'PBESM': ('PB', 'ESM'),
 	'PBENFR': ('PB', 'EN', 'FR'),
+	'DEIT': ('DE', 'IT'),
 }
 
 
@@ -51,8 +52,12 @@ def extract_sentences(file_info: FileInfo):
 
 	# if it's GMS C, it'll have more than 100 sentences (100 + the intro and outro)
 	if len(chunks) > 100:
-		# skip intro + all language names
-		chunks = chunks[len(languages):-2]
+		if "DE" in languages and "IT" in languages:
+			# DEIT has one more to skip
+			chunks = chunks[len(languages)+1:-2]
+		else:
+			# skip intro + all language names
+			chunks = chunks[len(languages):-2]
 	else:
 		# skip intro + target language name
 		chunks = chunks[2:-2]


### PR DESCRIPTION
It seems the DEIT course which I own has one more intro text to skip.

Not sure if its the best solution, but at least it will work for users
with that course for now. Maybe we should change it later to something
more general.

It would be good to find out if courses that were released in different
years have a different intro/outro text and whether we can detect this.

Related to https://github.com/chickendude/GlossikaNativeGLS/issues/1